### PR TITLE
Creacion vista Ciclorutas de Bogota

### DIFF
--- a/back/src/main/resources/templates/RutaFront.html
+++ b/back/src/main/resources/templates/RutaFront.html
@@ -84,25 +84,8 @@
 <!-- Mapa de OpenStreetMap -->
 <div id="map"></div>
 
-<!-- Contenedor para las etiquetas e inputs del usuario -->
-<div class="container">
-    <div class="row">
-        <div class="col-md-6">
-            <h2>Desde</h2>
-            <div class="custom-input">
-                <label for="etiqueta1">Inicio ruta:</label>
-                <input type="text" id="etiqueta1" class="form-control">
-            </div>
-        </div>
-        <div class="col-md-6">
-            <h2>Hasta</h2>
-            <div class="custom-input">
-                <label for="etiqueta2">Fin ruta:</label>
-                <input type="text" id="etiqueta2" class="form-control">
-            </div>
-        </div>
-    </div>
-</div>
+<br>
+
 <!-- Botón desplegable para seleccionar el tramo -->
 <div class="container text-left mt-3">
     <div class="dropdown d-inline-block">

--- a/back/src/main/resources/templates/mapaCiclovia.html
+++ b/back/src/main/resources/templates/mapaCiclovia.html
@@ -8,7 +8,7 @@
     <!-- Agrega los enlaces a los archivos CSS y JavaScript de Bootstrap -->
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
-          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
+          integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.3/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
@@ -27,6 +27,11 @@
             font-size: 40px;
             font-family: 'Bodoni MT', sans-serif;
         }
+
+        #map-container {
+            width: 100%; /* Ajusta el ancho del mapa para que ocupe todo el contenedor */
+            transition: transform 0.5s; /* Agrega una transición suave para la rotación */
+        }
     </style>
 
 
@@ -34,24 +39,23 @@
 
 <body>
 <nav class="navbar navbar-expand-lg navbar-light custom-navbar py-4">
-    <button class="btn btn-light" onclick="history.go(-1)"><svg xmlns="http://www.w3.org/2000/svg" width="16"
-                                                                height="16" fill="currentColor" class="bi bi-arrow-return-left" viewBox="0 0 16 16">
-        <path fill-rule="evenodd"
-              d="M14.5 1.5a.5.5 0 0 1 .5.5v4.8a2.5 2.5 0 0 1-2.5 2.5H2.707l3.347 3.346a.5.5 0 0 1-.708.708l-4.2-4.2a.5.5 0 0 1 0-.708l4-4a.5.5 0 1 1 .708.708L2.707 8.3H12.5A1.5 1.5 0 0 0 14 6.8V2a.5.5 0 0 1 .5-.5z" />
-    </svg></button>
+    <button class="btn btn-light" onclick="history.go(-1)">
+        <svg xmlns="http://www.w3.org/2000/svg" width="16"
+             height="16" fill="currentColor" class="bi bi-arrow-return-left" viewBox="0 0 16 16">
+            <path fill-rule="evenodd"
+                  d="M14.5 1.5a.5.5 0 0 1 .5.5v4.8a2.5 2.5 0 0 1-2.5 2.5H2.707l3.347 3.346a.5.5 0 0 1-.708.708l-4.2-4.2a.5.5 0 0 1 0-.708l4-4a.5.5 0 1 1 .708.708L2.707 8.3H12.5A1.5 1.5 0 0 0 14 6.8V2a.5.5 0 0 1 .5-.5z"/>
+        </svg>
+    </button>
     <span class="navbar-text mx-auto">
-            <span class="text-white custom-header">Mapa de la Ciclovía de Bogotá</span>
+            <span class="text-white custom-header">Ciclorutas de Bogotá</span>
         </span>
-    <a href="#otra-pestana" class="btn btn-light">Buscar</a>
 </nav>
 
-<br>
-<br>
-
 <!-- Contenedor principal -->
-<div class="container text-center">
+<div id="map-container">
+    <div id="map" style="height: 550px;">
 
-    <div id="map" style="height: 400px;">
+
         <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
                 integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
 
@@ -75,25 +79,54 @@
 
             // Mostrar [latitud, longitud] en el mapa
             map.on('click', onMapClick)
+
             // Evento es donde se esta dando click en el mapa
             function onMapClick(evento) {
                 alert("Posicion: " + evento.latlng)
             }
-
-
-
         </script>
     </div>
+
+    <br>
+
+    <div class="container">
+        <div class="row">
+            <div class="col-md-6">
+                <h2>Desde</h2>
+                <div class="custom-input">
+                    <label for="etiqueta1">Inicio ruta:</label>
+                    <input type="text" id="etiqueta1" class="form-control">
+                </div>
+            </div>
+            <div class="col-md-6">
+                <h2>Hasta</h2>
+                <div class="custom-input">
+                    <label for="etiqueta2">Fin ruta:</label>
+                    <input type="text" id="etiqueta2" class="form-control">
+                </div>
+            </div>
+        </div>
+    </div>
+
+
+
     <br>
     <!-- Botón centrado en la parte inferior -->
     <!-- <a href="#otra-pestana" class="btn btn-success btn-lg mt-3">Iniciar nueva ruta</a> -->
-    <a href="#otra-pestana" class="btn btn-lg mt-3 btn-green">Iniciar nueva ruta</a>
+    <div class="container text-center">
+        <a href="#otra-pestana" class="btn btn-lg mt-3 btn-green">Iniciar nueva ruta</a>
+    </div>
 
-    <br>
     <br>
 
     <!-- Link "¿Necesitas ayuda?" -->
-    <a href="#ayuda" class="text-muted font-weight-bold">¿Necesitas ayuda?</a>
+    <div class="container text-center">
+        <a href="#ayuda" class="text-muted font-weight-bold">¿Necesitas ayuda?</a>
+    </div>
+
+
+    <br>
+    <br>
 </div>
 
 <!-- Enlace a otra pestaña -->


### PR DESCRIPTION
Se creo la vista ciclorutas de Bogotá para usar entre semana, también desde la principal de ciclovía fin de semana se elimaron los labels que no tenían función puesto que quedó automático con la ubicación